### PR TITLE
[feat] 로그인 유무에 따른 매도 / 매수 컴포넌트 UI 변화를 구현한다.

### DIFF
--- a/src/components/right/contents/order/OrderForm.tsx
+++ b/src/components/right/contents/order/OrderForm.tsx
@@ -1,7 +1,9 @@
 import { faArrowRotateRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { changeNumber, dotQuantity, formatNumber, getPriceTickSize } from '../../../../lib/price';
+import useUserStore from '../../../../store/useUserStore';
 import Button from '../../../common/Button';
 import type { BuyOrderInitialData, SellOrderInitialData } from './types';
 
@@ -14,6 +16,8 @@ type OrderFormProps = {
 };
 
 const OrderForm = ({ orderType, initialData, onOrder }: OrderFormProps) => {
+  const navigate = useNavigate();
+  const { user } = useUserStore();
   const isBuy = orderType === 'buy';
   const data = initialData as BuyOrderInitialData | SellOrderInitialData;
 
@@ -153,18 +157,41 @@ const OrderForm = ({ orderType, initialData, onOrder }: OrderFormProps) => {
         />
       </div>
 
-      {/* 초기화, 매도/매수 버튼 */}
+      {/* 하단 버튼 */}
       <div className="flex gap-2 mt-4">
-        <button
-          onClick={handleReset}
-          className="flex flex-1 px-4 py-2 text-white bg-gray-400 rounded-[2px] text-[13px] items-center justify-center gap-1 cursor-pointer"
-        >
-          <FontAwesomeIcon icon={faArrowRotateRight} />
-          <span>초기화</span>
-        </button>
-        <Button colorType={buttonColorType} onClick={handleOrder} className="flex-4 w-full rounded-[2px] text-[13px]">
-          {orderButtonText}
-        </Button>
+        {user ? (
+          <>
+            <button
+              onClick={handleReset}
+              className="flex flex-1 px-4 py-2 text-white bg-gray-400 rounded-[2px] text-[13px] items-center justify-center gap-1 cursor-pointer"
+            >
+              <FontAwesomeIcon icon={faArrowRotateRight} />
+              <span>초기화</span>
+            </button>
+            <Button
+              colorType={buttonColorType}
+              onClick={handleOrder}
+              className="flex-4 w-full rounded-[2px] text-[13px]"
+            >
+              {orderButtonText}
+            </Button>
+          </>
+        ) : (
+          <>
+            <button
+              onClick={() => navigate('/signup')}
+              className="flex flex-1 px-4 py-2 text-white bg-blue-800 rounded-[2px] text-[13px] items-center justify-center cursor-pointer"
+            >
+              <span>회원가입</span>
+            </button>
+            <button
+              onClick={() => navigate('/login')}
+              className="flex flex-4 w-full px-4 py-2 text-white bg-blue-500 rounded-[2px] text-[13px] items-center justify-center cursor-pointer"
+            >
+              <span>로그인</span>
+            </button>
+          </>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## 🚨 관련 이슈

[//]: # "작성하실 때는 '#이슈 번호'를 남겨주시면 자동으로 링크가 생성됩니다."

#40 

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

[//]: # "작업 내용을 작성해주세요. 스크린샷을 첨부해주셔도 좋습니다."

<img width="496" height="441" alt="스크린샷 2026-01-05 오후 11 55 25" src="https://github.com/user-attachments/assets/e390ec13-5bde-484d-ba93-11daf29275d3" />


- 로그인 하지 않았을 시 초기화 / 매수 버튼 -> 회원가입 / 로그인 버튼으로 대체되도록 구현하였습니다.