### PR TITLE
[fix] ticker endPoint webSocket data가 string데이터로 내려오는 상황에 대응한다.

### DIFF
--- a/src/components/market/MarketTableItem.tsx
+++ b/src/components/market/MarketTableItem.tsx
@@ -113,7 +113,7 @@ export default function MarketTableItem({
 
   // /topic/ticker에서 데이터 가져옴
   const lastPrice = ticker?.price ?? 0;
-  const changeRate = ticker?.changeRate ?? 0;
+  const changeRate = Number(ticker?.changeRate ?? 0);
   const tradeAmount = ticker?.amount ?? 0;
   const isLiveTicker = !!ticker;
 

--- a/src/components/orderbook/TradeTapeSection.tsx
+++ b/src/components/orderbook/TradeTapeSection.tsx
@@ -7,7 +7,7 @@ export default function TradeTapeSection() {
   // 체결강도 포맷팅
   const formatTradeStrength = (value: number): string => {
     const sign = value >= 0 ? '+' : '';
-    return `${sign}${value.toFixed(2)}%`;
+    return `${sign}${Number(value).toFixed(2)}%`;
   };
 
   // 최신 체결강도 (가장 최근 체결의 intensity 사용)


### PR DESCRIPTION
## 🚨 관련 이슈

[//]: # "작성하실 때는 '#이슈 번호'를 남겨주시면 자동으로 링크가 생성됩니다."

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

ticker endPoint webSocket data가 string데이터로 내려오는 상황이라 에러가 났었는데 해당 함수랑 사용처에서 Number 타입으로 변환하도록 수정하였습니다.