### PR TITLE
[fix] 당일 고가 저가 +/- 표시를 하는 함수를 수정한다.

### DIFF
--- a/src/components/orderbook/MarketSummaryPanel.tsx
+++ b/src/components/orderbook/MarketSummaryPanel.tsx
@@ -24,8 +24,6 @@ export default function MarketSummaryPanel() {
   // 전일종가는 /topic/trades에서 받아옴
   const previousClose = tradesData?.openPrice ?? 0;
 
-  // 변동률 포맷팅
-
   // 고가/저가 변동률 계산
   const highChangeRate =
     previousClose !== 0 ? ((high - previousClose) / previousClose) * 100 : (categoryInfo?.changeRate ?? 0);


### PR DESCRIPTION
## 🚨 관련 이슈

[//]: # "작성하실 때는 '#이슈 번호'를 남겨주시면 자동으로 링크가 생성됩니다."

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

[//]: # "작업 내용을 작성해주세요. 스크린샷을 첨부해주셔도 좋습니다."

- 당일 고가/저가가 모두 +로 확인. 내려오는 값이 0보다 크면 +로 return 하는 함수로 사용하고 있었어서 하드코딩으로 수정