### PR TITLE
매도 주문 가능 수량이 없으면 0이 아닌 공백으로 뜨는 이슈에 대응한다.

### DIFF
--- a/src/lib/price.ts
+++ b/src/lib/price.ts
@@ -40,7 +40,7 @@ export const deleteZero = (coin: string): string => {
 // 소숫점 8째자리까지 표시하기 (소숫점 9째자리부터는 반올림되어 표시되지 않음)
 // 뒷자리 0 나열 제거
 export const dotQuantity = (point: number): string => {
-  if (point === 0) return '';
+  if (point === 0) return '0';
   return point.toFixed(8).replace(/\.?0+$/, '');
 };
 


### PR DESCRIPTION
## 🚨 관련 이슈

[//]: # "작성하실 때는 '#이슈 번호'를 남겨주시면 자동으로 링크가 생성됩니다."

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

[//]: # "작업 내용을 작성해주세요. 스크린샷을 첨부해주셔도 좋습니다."

- dotQuantity 함수가 point가 없으면 ''을 리턴하고 있어서 수량이 뜨지 않았었습니다.
- 다시 0을 리턴하도록 수정하였습니다.