### PR TITLE
[refactor] 관심 버튼의 불필요한 렌더링을 방지하기 위한 렌더링 최적화를 진행한다.

### DIFF
--- a/src/components/market/MarketTableItem.tsx
+++ b/src/components/market/MarketTableItem.tsx
@@ -1,6 +1,7 @@
 import { faStar as faStarRegular } from '@fortawesome/free-regular-svg-icons';
 import { faStar as faStarSolid } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { memo } from 'react';
 import FlashComparison from './FlashComparison';
 import { formatChangePricePercentage } from '../../lib/price';
 import useCategoryIdStore from '../../store/useCategoryId';
@@ -8,6 +9,40 @@ import { useTickerStore } from '../../store/websocket/useTickerStore';
 import type { TAssets } from '../../types/asset';
 import type { Category } from '../../types/category';
 import type { TabKey } from '../../types/market';
+
+// 얘는 ticker 구독 안 해서 뺴고 memo 처리 (아이콘 렌더링 방지)
+const MarketTableItemSymbol = memo(function MarketTableItemSymbol({
+  categoryName,
+  symbol,
+  isFavorite,
+  onToggleFavorite,
+}: {
+  categoryName: string;
+  symbol: string;
+  isFavorite: boolean;
+  onToggleFavorite: () => void;
+}) {
+  return (
+    <div className="text-xs min-w-0">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleFavorite();
+          }}
+          className="w-5 h-5 flex items-center justify-center text-[#ffca43] hover:text-[#ffb457] shrink-0"
+        >
+          <FontAwesomeIcon icon={isFavorite ? faStarSolid : faStarRegular} />
+        </button>
+        <div className="flex flex-col min-w-0">
+          <span className="text-[13px] font-semibold text-primary-100">{categoryName}</span>
+          <span className="text-[11px] text-primary-300">{symbol}/(KRW)</span>
+        </div>
+      </div>
+    </div>
+  );
+});
 
 type MarketTableItemProps = {
   activeTab: TabKey;
@@ -113,26 +148,12 @@ export default function MarketTableItem({
       }`}
       onClick={() => setCategoryId(category.categoryId)}
     >
-      <div className="text-xs min-w-0">
-        <div className="flex items-center gap-2">
-          {/* 관심 종목 추가/삭제 버튼 */}
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              onToggleFavorite();
-            }}
-            className="w-5 h-5 flex items-center justify-center text-[#ffca43] hover:text-[#ffb457] shrink-0"
-          >
-            <FontAwesomeIcon icon={isFavorite ? faStarSolid : faStarRegular} />
-          </button>
-          {/* 종목명 심볼 표시 */}
-          <div className="flex flex-col min-w-0">
-            <span className="text-[13px] font-semibold text-primary-100">{category.categoryName}</span>
-            <span className="text-[11px] text-primary-300">{category.symbol}/(KRW)</span>
-          </div>
-        </div>
-      </div>
+      <MarketTableItemSymbol
+        categoryName={category.categoryName}
+        symbol={category.symbol}
+        isFavorite={isFavorite}
+        onToggleFavorite={onToggleFavorite}
+      />
       <FlashComparison
         value={isLiveTicker ? lastPrice : null}
         enabled={isLiveTicker}


### PR DESCRIPTION
## 🚨 관련 이슈

[//]: # "작성하실 때는 '#이슈 번호'를 남겨주시면 자동으로 링크가 생성됩니다."

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

[//]: # "작업 내용을 작성해주세요. 스크린샷을 첨부해주셔도 좋습니다."

- MarketItem 컴포넌트 내부의 관심 아이콘에 실시간 데이터가 필요없음에도 불구하고 store 구독으로 인해 렌더링 되길래 상단에 다른 컴포넌트로 분리하여 렌더링 방지하였습니다.